### PR TITLE
 Fix issue related to numeric IDs acting as indices 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.4
+## 25-07-2019
+
+1. [](#bugfix)
+    - Fixed bug related to numeric IDs.
+
 # v0.1.3
 ## 24-07-2019
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The heading for the reference section defaults to "References", but can be set i
 
 I welcome PRs for internationalisation and addition of new citation types.
 
-However, if you prefer to create new citations types locally, you can extending the plugin without needing to fork it by following the instructions below.
+However, if you prefer to create new citations types locally, you can extend the plugin without needing to fork it by following the instructions below.
 
 ### Adding reference types
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Shortcode Citations
-version: 0.1.3
+version: 0.1.4
 description: "Provides the ability to add citations via shortcodes such as [cite=id /]"
 icon: superscript
 author:

--- a/shortcodes/CitationShortcode.php
+++ b/shortcodes/CitationShortcode.php
@@ -13,7 +13,7 @@ class CitationShortcode extends Shortcode
         $citeNum = $this->grav['citations']->getCitationNumber($citeId);
         return '<a class="citation" href="#cite-'.$citeId.'">['.$citeNum.']</a>';
       } else {
-        // Get variables        
+        // Get variables
         $vars = array(
           "page" => $this->grav["page"],
           "citations" => $this->grav['citations']->getCitations(),

--- a/templates/partials/citations.html.twig
+++ b/templates/partials/citations.html.twig
@@ -9,7 +9,8 @@
 {% set references = {} %}
 
 {% for ref in reference_list %}
-  {% set references = references|merge({(ref["id"]): ref}) %}
+  {# Adding "ref-" avoids issues with numeric IDs acting as indices #}
+  {% set references = references|merge({("ref-"~ref["id"]): ref}) %}
 {% endfor %}
 
 
@@ -27,7 +28,7 @@
 
     <ol>
       {% for citeId in citations %}
-        {% set reference = references[citeId] %}
+        {% set reference = references["ref-"~citeId] %}
 
         {% if reference %}
           {% include 'partials/citations/'~reference.type~'.html.twig' with { 'ref': reference } %}


### PR DESCRIPTION
This PR fixes an issue with numeric reference IDs.

Twig was treating numeric IDs as indices of the array, rather than as keys. Prepending a string to all IDs in the template forces Twig to treat them as strings and thus as keys. The same issue doesn't appear to affect PHP, so this prefix is only included in the Twig for simplicity.