### PR TITLE
Add ability to list uncited works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.2.0
+## 26-07-2019
+
+1. [](#new)
+    - Added option for listing only cited, uncited, or all references from the page.
+    - Added option for whether to reorder uncited works alphabetically by ID.
+
 # v0.1.4
 ## 25-07-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # v0.2.0
-## 26-07-2019
+## 31-07-2019
 
 1. [](#new)
     - Added option for listing only cited, uncited, or all references from the page.
     - Added option for whether to reorder uncited works alphabetically by ID.
+
+2. [](#bugfix)
+    - Fixed issue with citations in blog posts displaying incorrectly in the listing.
 
 # v0.1.4
 ## 25-07-2019

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ The reference list can be printed either by adding `[cite /]` with no key id, or
 
 The heading for the reference section defaults to "References", but can be set in the plugin config via `heading_text` or as an option in the shortcode used to print it (eg. `[cite heading=Bibliography /]`). The title can also be disabled by setting the heading text to "false" via the same methods.
 
+#### Configuring the reference list via shortcode:
+
+Configuration options set in the shortcode override those in the plugin config and page header.
+
+- "heading": (text) Sets the text of the heading. Can be set to "false" or "0" to disable it.
+- "items": ("cited", "all", "uncited") Determines the works to include in the reference list.
+- "reorder": (bool) Whether to reorder uncited works alphabetically (by ID). Set this to "false" or "0" to disable reordering and list uncited works in the order defined in the page header.
+
+#### Configuring the reference list via plugin/page config:
+
+All of these options can be set in the plugin config to affect the whole site, or on a page-level via the "Option" tab (or as entries under `shortcode_citation` in the page header).
+
+- "heading_text": (text) Sets the text of the heading. Can be set to "false" to disable it.
+- "items": ("cited", "all", "uncited") Determines the works to include in the reference list.
+- "reorder_uncited": (bool) Whether to reorder uncited works alphabetically (by ID). Set this to "false" to disable reordering and list uncited works in the order defined in the page header.
+
 
 ## Customisation and extension
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Alternatively it can be installed via the [Admin Plugin](http://learn.getgrav.or
 
 ### Adding references
 
-The plugin adds a References section to pages inheriting the "default" blueprint. The references are stored per-page and only those that are cited in the page will be listed in the reference section. The order of the references in the list doesn't matter; they will always print in the order that they are cited in the text. The id entered **must** be unique.
+The plugin adds a References section to pages inheriting the "default" blueprint. The references are stored per-page and by default only those that are cited in the page will be listed in the reference section. The order of the references in the list doesn't matter; they will always print in the order that they are cited in the text. The id entered **must** be unique.
 
 This plugin is mostly to make citations easier, so the reference printing logic is currently quite simplistic; text is mostly printed as-is. This means that you are responsible for consistency of things like the format of author names, but also adds some flexibility to bend the rules a little bit. If a field is left empty or is not considered relevant for that reference type, it will be ignored.
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Shortcode Citations
-version: 0.1.4
+version: 0.2.0
 description: "Provides the ability to add citations via shortcodes such as [cite=id /]"
 icon: superscript
 author:
@@ -23,8 +23,8 @@ form:
       highlight: 1
       default: 1
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
     builtin_css:
@@ -33,12 +33,30 @@ form:
       highlight: 1
       default: 1
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
     heading_text:
       type: text
       label: Heading text
       placeholder: "References"
+    items:
+      type: select
+      label: Works to reference
+      help: 
+      options:
+        "cited": Only cited works
+        "all": All works
+        "uncited": Only uncited works
+    reorder_uncited:
+      type: toggle
+      label: Order uncited works alphabetically (by ID)
+      highlight: 1
+      default: 1
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
 

--- a/blueprints/default.yaml
+++ b/blueprints/default.yaml
@@ -58,4 +58,31 @@ form:
                       type: text
                       label: Page numbers (x-y)
 
-              
+        options:
+          fields:
+            shortcode-citation:
+              type: section
+              title: Shortcode Citation
+              fields:
+                header.shortcode-citation.heading_text:
+                  type: text
+                  label: Heading text
+                  placeholder: "References"
+                header.shortcode-citation.items:
+                  type: select
+                  label: Works to reference
+                  help: 
+                  options:
+                    "cited": Only cited works
+                    "all": All works
+                    "uncited": Only uncited works
+                header.shortcode-citation.reorder_uncited:
+                  type: toggle
+                  label: Order uncited works alphabetically (by ID)
+                  highlight: 1
+                  default: 1
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED
+                  validate:
+                    type: bool

--- a/css/citations.css
+++ b/css/citations.css
@@ -10,9 +10,9 @@
   font-weight: bold;
 }
 
-.references .highlight li:target {
+.references li:target {
   background: #0002;
-  
+
 }
 
 .references li {

--- a/shortcode-citation.php
+++ b/shortcode-citation.php
@@ -76,7 +76,6 @@ class CitationManager
 
     public function getCitationNumber($citeId)
     {
-        
         if ( in_array($citeId, $this->citations) ) {
             $citeNum = array_search($citeId, $this->citations) + 1;
         } else {

--- a/shortcodes/CitationShortcode.php
+++ b/shortcodes/CitationShortcode.php
@@ -8,16 +8,26 @@ class CitationShortcode extends Shortcode
   public function init()
   {
     $this->shortcode->getHandlers()->add('cite', function(ShortcodeInterface $sc) {
-      $citeId = $sc->getParameter('cite', $this->getBbCode($sc));
-      if ($citeId) {
+      $options = $this->getBbCode($sc);
+      $citeId = $sc->getParameter('cite', $options);
+      if (isset($citeId)) {
         $citeNum = $this->grav['citations']->getCitationNumber($citeId);
         return '<a class="citation" href="#cite-'.$citeId.'">['.$citeNum.']</a>';
       } else {
+        // Determine the boolean value of 'reorder' if set
+        $reorder = $sc->getParameter('reorder', $options);
+        if (isset($reorder)) {
+          // Consider most things to be truthy
+          $reorder = !($reorder === "false" || $reorder === "0");
+        }
+
         // Get variables
         $vars = array(
           "page" => $this->grav["page"],
           "citations" => $this->grav['citations']->getCitations(),
-          "heading" => $sc->getParameter('heading', $this->getBbCode($sc)),
+          "heading" => $sc->getParameter('heading', $options),
+          "items" => $sc->getParameter('items', $options),
+          "reorder" => $reorder,
         );
 
         // Process Twig template

--- a/templates/partials/citations.html.twig
+++ b/templates/partials/citations.html.twig
@@ -1,8 +1,14 @@
-{# 'citations' is an ordered list of references provided by the plugin  #}
+{# 'citations' is an ordered list of references provided by the plugin #}
+{# Config resolution is handled here so that other templates can 'include' this one #}
 
-{% if config.plugins["shortcode-citation"]["builtin_css"] %}
+{% set page_config = page.header.shortcode_citation %}
+{% set plugin_config = config.plugins["shortcode-citation"] %}
+
+
+{% if plugin_config.builtin_css %}
   {% do assets.addCss("plugins://shortcode-citation/css/citations.css") %}
 {% endif %}
+
 
 
 {% set reference_list = page.header.references %}
@@ -14,9 +20,36 @@
 {% endfor %}
 
 
+{# Alphabetise/Reorder references if required #}
+{% if reorder ?: page_config.reorder_uncited ?: plugin_config.reorder_uncited %}
+  {% set references = references|ksort %}
+{% endif %}
+
+
 {# 'heading' comes via Shortcode #}
 {% if not heading is same as("false") %}
-  {% set heading_text = heading ?: config['plugins.shortcode-citation.heading_text'] ?: "References" %}
+  {% set heading_text = heading ?: page_config.heading_text ?: plugin_config.heading_text ?: "References" %}
+{% endif %}
+
+
+{% set items = items ?: page_config.items ?: plugin_config.items %}
+
+
+{% if items is same as("all") %}
+  {# Append the keys for uncited works #}
+  {% for key in references|keys %}
+    {% if key[4:] not in citations %}
+      {% set citations = citations|merge([key[4:]]) %}
+    {% endif %}
+  {% endfor %}
+{% elseif items is same as("uncited") %}
+  {% set uncited = [] %}
+  {% for key in references|keys %}
+    {% if key[4:] not in citations %}
+      {% set uncited = uncited|merge([key[4:]]) %}
+    {% endif %}
+  {% endfor %}
+  {% set citations = uncited %}
 {% endif %}
 
 

--- a/templates/partials/citations.html.twig
+++ b/templates/partials/citations.html.twig
@@ -27,7 +27,7 @@
 
 
 {# 'heading' comes via Shortcode #}
-{% if not heading is same as("false") %}
+{% if not heading is same as("false") and not heading == 0 %}
   {% set heading_text = heading ?: page_config.heading_text ?: plugin_config.heading_text ?: "References" %}
 {% endif %}
 

--- a/templates/partials/citations.html.twig
+++ b/templates/partials/citations.html.twig
@@ -4,17 +4,18 @@
 {% set page_config = page.header.shortcode_citation %}
 {% set plugin_config = config.plugins["shortcode-citation"] %}
 
-
 {% if plugin_config.builtin_css %}
   {% do assets.addCss("plugins://shortcode-citation/css/citations.css") %}
 {% endif %}
 
+{# Get the list of citations #}
 {% set cites = citations.getCitations() %}
 
-
+{# Get the reference list #}
 {% set reference_list = page.header.references %}
 {% set references = {} %}
 
+{# Reorganise the reference list to use the ID as a key #}
 {% for ref in reference_list %}
   {# Adding "ref-" avoids issues with numeric IDs acting as indices #}
   {% set references = references|merge({("ref-"~ref["id"]): ref}) %}
@@ -22,38 +23,49 @@
 
 
 {# Alphabetise/Reorder references if required #}
-{% if reorder ?: page_config.reorder_uncited ?: plugin_config.reorder_uncited %}
+{% if ((reorder is defined) ? reorder : (page_config.reorder_uncited is defined) ? page_config.reorder_uncited : (plugin_config.reorder_uncited is defined) ? plugin_config.reorder_uncited : true) %}
   {% set references = references|ksort %}
 {% endif %}
 
 
-{# 'heading' comes via Shortcode #}
-{% if not heading is same as("false") and not heading == 0 %}
-  {% set heading_text = heading ?: page_config.heading_text ?: plugin_config.heading_text ?: "References" %}
-{% endif %}
+{# Determine the heading text #}
+{% set falsey = ["", 0, "0", false, "false"] %}
+{% set heading_text =
+  (
+    heading is defined
+  ) ? heading : (
+    page_config.heading_text is defined
+  ) ? page_config.heading_text : (
+    plugin_config.heading_text is defined
+  ) ? plugin_config.heading_text : (
+    "References"
+  )
+%}
+{% set heading_text = (falsey == falsey|merge([heading_text])) ? false : heading_text %}
 
 
+{# Determine which items to show #}
 {% set items = items ?: page_config.items ?: plugin_config.items %}
-
 
 {% if items is same as("all") %}
   {# Append the keys for uncited works #}
   {% for key in references|keys %}
-    {% if key[4:] not in citations %}
-      {% set citations = citations|merge([key[4:]]) %}
+    {% if key[4:] not in cites %}
+      {% set cites = cites|merge([key[4:]]) %}
     {% endif %}
   {% endfor %}
 {% elseif items is same as("uncited") %}
   {% set uncited = [] %}
   {% for key in references|keys %}
-    {% if key[4:] not in citations %}
+    {% if key[4:] not in cites %}
       {% set uncited = uncited|merge([key[4:]]) %}
     {% endif %}
   {% endfor %}
-  {% set citations = uncited %}
+  {% set cites = uncited %}
 {% endif %}
 
 
+{# Print the citation list (if there are citations) #}
 {% if cites %}
   <section class="references">
     {% if heading_text %}


### PR DESCRIPTION
This PR adds the ability to list works that are listed in the page's references, but which have not been directly cited.

This is achieved via the `items` option for the plugin config, page header, and shortcode options, with the 3 keywords (`cited`, `uncited`, `all`) providing obvious behaviour.